### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete multi-character sanitization

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
     const cheerio = require('cheerio');
     const fs = require('fs');
     const http = require('http');
+    const sanitizeHtml = require('sanitize-html');
 
     const config = require('./config');
     const helper = require('./helper');
@@ -119,7 +120,7 @@
                 problem.question = $('div.question-content__JfgR > div').html();
 
                 if (problem.question != null && problem.question.length > 0) {
-                    problem.question = problem.question.replace(/<[^>]+>/g, '');
+                    problem.question = sanitizeHtml(problem.question, { allowedTags: [], allowedAttributes: {} });
                 }
 
                 $('div.CodeMirror-code div').each(function (index, element) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "license": "ISC",
   "dependencies": {
     "cheerio": "^1.1.0",
-    "puppeteer": "^24.10.2"
+    "puppeteer": "^24.10.2",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "eslint": "^9.29.0",


### PR DESCRIPTION
Potential fix for [https://github.com/tarunbatta/leetcodeScraper/security/code-scanning/1](https://github.com/tarunbatta/leetcodeScraper/security/code-scanning/1)

To fix the issue, the sanitization process should be updated to ensure that all unsafe HTML tags are removed. This can be achieved by applying the regular expression replacement repeatedly until no more replacements can be performed. Alternatively, a well-tested library like `sanitize-html` can be used to handle sanitization comprehensively.

The best approach here is to use the `sanitize-html` library, as it is specifically designed to handle HTML sanitization and ensures that all unsafe tags and attributes are removed. This approach is robust and avoids potential edge cases that might arise with custom regular expressions.

Changes to make:
1. Add the `sanitize-html` library to the project.
2. Replace the current sanitization logic on line 122 with a call to `sanitize-html`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
